### PR TITLE
Add support for custom E621ng image boards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Jetbrains Rider specific configuration
+.idea

--- a/E621Client.DbExport/E621DbExportClient.cs
+++ b/E621Client.DbExport/E621DbExportClient.cs
@@ -73,8 +73,10 @@ namespace Noppes.E621.DbExport
 
         internal E621DbExportClient(IE621Client e621Client)
         {
-            if (e621Client.Imageboard == Imageboard.E926)
-                throw new ArgumentException("e926 does not support database exports. You need to use a client configured to use e621.", nameof(e621Client));
+#pragma warning disable CS0612 CS0618 // Type or member is obsolete We still need to actually do this check because older clients might still be using Imageboard.
+            if (e621Client.Imageboard != Imageboard.E621 && !e621Client.BaseUrl.Equals(E621Constants.E621BaseUrl.AbsoluteUri))
+#pragma warning restore CS0612 CS0618 // Type or member is obsolete
+                throw new ArgumentException("Only e621 supports database exports. You need to use a client configured to use e621.", nameof(e621Client));
 
             _e621Client = e621Client;
         }

--- a/E621Client.DbExport/E621DbExportClient.cs
+++ b/E621Client.DbExport/E621DbExportClient.cs
@@ -74,7 +74,7 @@ namespace Noppes.E621.DbExport
         internal E621DbExportClient(IE621Client e621Client)
         {
 #pragma warning disable CS0612 CS0618 // Type or member is obsolete We still need to actually do this check because older clients might still be using Imageboard.
-            if (e621Client.Imageboard != Imageboard.E621 && !e621Client.BaseUrl.Equals(E621Constants.E621BaseUrl.AbsoluteUri))
+            if (!e621Client.BaseUrl.Equals(E621Constants.E621BaseUrl.AbsoluteUri))
 #pragma warning restore CS0612 CS0618 // Type or member is obsolete
                 throw new ArgumentException("Only e621 supports database exports. You need to use a client configured to use e621.", nameof(e621Client));
 

--- a/E621Client.DbExport/E621DbExportClient.cs
+++ b/E621Client.DbExport/E621DbExportClient.cs
@@ -73,9 +73,7 @@ namespace Noppes.E621.DbExport
 
         internal E621DbExportClient(IE621Client e621Client)
         {
-#pragma warning disable CS0612 CS0618 // Type or member is obsolete We still need to actually do this check because older clients might still be using Imageboard.
             if (!e621Client.BaseUrl.Equals(E621Constants.E621BaseUrl.AbsoluteUri))
-#pragma warning restore CS0612 CS0618 // Type or member is obsolete
                 throw new ArgumentException("Only e621 supports database exports. You need to use a client configured to use e621.", nameof(e621Client));
 
             _e621Client = e621Client;

--- a/E621Client/E621Client.cs
+++ b/E621Client/E621Client.cs
@@ -16,7 +16,7 @@ namespace Noppes.E621
     public partial class E621Client : IE621Client
     {
         /// <inheritdoc/>
-        [Obsolete]
+        [Obsolete("Imageboard is no longer used, Use the BaseUrl to determine which image board the client is talking to.")]
         public Imageboard Imageboard { get; }
 
         /// <inheritdoc/>
@@ -40,7 +40,7 @@ namespace Noppes.E621
         private readonly IFlurlClient _flurlClient;
         private readonly E621RequestHandler _requestHandler;
 
-        [Obsolete]
+        [Obsolete("Do no longer construct E621Client using an Imageboard, call the constructor with Uri instead.")]
         internal E621Client(Imageboard imageboard, E621UserAgent userAgent, TimeSpan requestInterval, int maximumConnections)
         {
             Imageboard = imageboard;

--- a/E621Client/E621Client.cs
+++ b/E621Client/E621Client.cs
@@ -63,7 +63,7 @@ namespace Noppes.E621
         internal E621Client(Uri imageboard, E621UserAgent userAgent, TimeSpan requestInterval, int maximumConnections)
         {
             BaseUrl = imageboard.AbsoluteUri;
-            _baseUrlRegistrableDomain = imageboard.Host; //TODO test if this gives the correct value.
+            _baseUrlRegistrableDomain = imageboard.Host;
 
             var httpClientHandler = new E621ClientHandler(maximumConnections);
             var httpClient = new HttpClient(httpClientHandler);

--- a/E621Client/E621ClientBuilder.cs
+++ b/E621Client/E621ClientBuilder.cs
@@ -53,13 +53,13 @@ namespace Noppes.E621
         /// <summary>
         /// Sets the image board used to retrieve data from using the base URL of the image board.
         /// </summary>
-        /// <param name="imageboardBaseUrl">The full absolute base URL to use the client on. For example https://e621.net</param>
-        /// <exception cref="ArgumentException">If the given <paramref name="imageboardBaseUrl"/> is not a valid absolute URL.</exception>
-        public E621ClientBuilder WithBaseUrl(Uri imageboardBaseUrl) => Set(() =>
+        /// <param name="baseUrl">The full absolute base URL to use the client on. For example https://e621.net</param>
+        /// <exception cref="ArgumentException">If the given <paramref name="baseUrl"/> is not a valid absolute URL.</exception>
+        public E621ClientBuilder WithBaseUrl(Uri baseUrl) => Set(() =>
         {
-            if (!imageboardBaseUrl.IsAbsoluteUri)
-                throw new ArgumentException("The base URL to an image board has to be a absolute URL!", nameof(imageboardBaseUrl));
-            BaseUrl = imageboardBaseUrl;
+            if (!baseUrl.IsAbsoluteUri)
+                throw new ArgumentException("The base URL to an image board has to be a absolute URL!", nameof(baseUrl));
+            BaseUrl = baseUrl;
         });
 
         /// <summary>

--- a/E621Client/E621ClientBuilder.cs
+++ b/E621Client/E621ClientBuilder.cs
@@ -58,7 +58,7 @@ namespace Noppes.E621
         public E621ClientBuilder WithBaseUrl(Uri baseUrl) => Set(() =>
         {
             if (!baseUrl.IsAbsoluteUri)
-                throw new ArgumentException("The base URL to an image board has to be a absolute URL!", nameof(baseUrl));
+                throw new ArgumentException("The base URL to an image board has to be a absolute URL!", "baseUrl");
             BaseUrl = baseUrl;
         });
 

--- a/E621Client/E621Constants.cs
+++ b/E621Client/E621Constants.cs
@@ -69,6 +69,22 @@ namespace Noppes.E621
         /// <summary>
         /// The default imageboard information is retrieved from.
         /// </summary>
+        [Obsolete("The use of Imageboard is no longer supported, use DefaultBaseUrl, E621BaseUrl or E921BaseUrl instead.")]
         public static readonly Imageboard DefaultImageboard = Imageboard.E621;
+
+        /// <summary>
+        /// The URL to the E621 imageboard.
+        /// </summary>
+        public static readonly Uri E621BaseUrl = new Uri("https://e621.net");
+        
+        /// <summary>
+        /// The URL to the E926 imageboard.
+        /// </summary>
+        public static readonly Uri E926BaseUrl = new Uri("https://e926.net");
+        
+        /// <summary>
+        /// The default URL for the imageboard information is retrieved from.
+        /// </summary>
+        public static readonly Uri DefaultBaseUrl = E621BaseUrl;
     }
 }

--- a/E621Client/E621Constants.cs
+++ b/E621Client/E621Constants.cs
@@ -69,7 +69,7 @@ namespace Noppes.E621
         /// <summary>
         /// The default imageboard information is retrieved from.
         /// </summary>
-        [Obsolete("The use of Imageboard is no longer supported, use DefaultBaseUrl, E621BaseUrl or E921BaseUrl instead.")]
+        [Obsolete("The use of Imageboard is no longer supported, use DefaultBaseUrl, E621BaseUrl or E926BaseUrl instead.")]
         public static readonly Imageboard DefaultImageboard = Imageboard.E621;
 
         /// <summary>

--- a/E621Client/IE621Client.cs
+++ b/E621Client/IE621Client.cs
@@ -13,6 +13,7 @@ namespace Noppes.E621
         /// <summary>
         /// The imageboard to which the requests are made.
         /// </summary>
+        [Obsolete]
         public Imageboard Imageboard { get; }
 
         /// <summary>

--- a/E621Client/IE621Client.cs
+++ b/E621Client/IE621Client.cs
@@ -13,7 +13,7 @@ namespace Noppes.E621
         /// <summary>
         /// The imageboard to which the requests are made.
         /// </summary>
-        [Obsolete]
+        [Obsolete("Imageboard is no longer used, Use the BaseUrl to determine which image board the client is talking to.")]
         public Imageboard Imageboard { get; }
 
         /// <summary>

--- a/E621Client/Imageboard.cs
+++ b/E621Client/Imageboard.cs
@@ -29,6 +29,7 @@ namespace Noppes.E621
         /// <summary>
         /// Maps the imageboard to a base URL that can be for HTTP clients.
         /// </summary>
+        [Obsolete("No longer supported to create a client with an image board. Use the WithBaseUrl(Uri) in the builder instead.")]
         public static (string registrableDomain, string baseUrl) AsBaseUrl(this Imageboard imageboard)
         {
             return imageboard switch

--- a/E621Client/Imageboard.cs
+++ b/E621Client/Imageboard.cs
@@ -5,6 +5,7 @@ namespace Noppes.E621
     /// <summary>
     /// Imageboards of which data can be retrieved from.
     /// </summary>
+    [Obsolete("Using the Imageboard is no longer recommended. Use the Url overload of WithBaseUrl instead.")]
     public enum Imageboard
     {
         /// <summary>
@@ -12,14 +13,9 @@ namespace Noppes.E621
         /// </summary>
         E621,
         /// <summary>
-        /// Use e921 as source for API requests.
+        /// Use e926 as source for API requests.
         /// </summary>
-        E926,
-        
-        /// <summary>
-        /// Use e6ai as source for API requests.
-        /// </summary>
-        E6AI
+        E926
     }
 
     internal static class ImageboardExtensions
@@ -30,9 +26,6 @@ namespace Noppes.E621
         private const string E921BaseUrlRegistrableDomain = "e926.net";
         private const string E921BaseUrl = "https://" + E921BaseUrlRegistrableDomain;
 
-        private const string E6AIBaseUrlRegistrableDomain = "e6ai.net";
-        private const string E6AIBaseUrl = "https://" + E6AIBaseUrlRegistrableDomain;
-
         /// <summary>
         /// Maps the imageboard to a base URL that can be for HTTP clients.
         /// </summary>
@@ -42,7 +35,6 @@ namespace Noppes.E621
             {
                 Imageboard.E621 => (E621BaseUrlRegistrableDomain, E621BaseUrl),
                 Imageboard.E926 => (E921BaseUrlRegistrableDomain, E921BaseUrl),
-                Imageboard.E6AI => (E6AIBaseUrlRegistrableDomain, E6AIBaseUrl),
                 _ => throw new ArgumentOutOfRangeException(nameof(imageboard))
             };
         }

--- a/E621Client/Imageboard.cs
+++ b/E621Client/Imageboard.cs
@@ -14,7 +14,12 @@ namespace Noppes.E621
         /// <summary>
         /// Use e921 as source for API requests.
         /// </summary>
-        E926
+        E926,
+        
+        /// <summary>
+        /// Use e6ai as source for API requests.
+        /// </summary>
+        E6AI
     }
 
     internal static class ImageboardExtensions
@@ -25,6 +30,9 @@ namespace Noppes.E621
         private const string E921BaseUrlRegistrableDomain = "e926.net";
         private const string E921BaseUrl = "https://" + E921BaseUrlRegistrableDomain;
 
+        private const string E6AIBaseUrlRegistrableDomain = "e6ai.net";
+        private const string E6AIBaseUrl = "https://" + E6AIBaseUrlRegistrableDomain;
+
         /// <summary>
         /// Maps the imageboard to a base URL that can be for HTTP clients.
         /// </summary>
@@ -34,6 +42,7 @@ namespace Noppes.E621
             {
                 Imageboard.E621 => (E621BaseUrlRegistrableDomain, E621BaseUrl),
                 Imageboard.E926 => (E921BaseUrlRegistrableDomain, E921BaseUrl),
+                Imageboard.E6AI => (E6AIBaseUrlRegistrableDomain, E6AIBaseUrl),
                 _ => throw new ArgumentOutOfRangeException(nameof(imageboard))
             };
         }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ var e621Client = new E621ClientBuilder()
     .Build();
 ```
 
+We've also added support to use this client for any website that is running the open source [E621ng](https://github.com/e621ng/e621ng) framework and thus is sharing the same API.
+For example ([E926](https://e926.net) or [E6AI](https://e6ai.net)).
+In order to change which image board the client is using you can use the `WithBaseUrl(Uri)` method on the `E621ClientBuilder` like below:
+
+_Example for use with a different E621ng image board_
+
+```csharp
+var e926Client = new E621ClientBuilder()
+    .WithUserAgent("MyApplicationName", "MyApplicationVersion", "MyTwitterUsername", "Twitter")
+    .WithBaseUrl(new Uri("https://e926.net"))
+    .Build();
+```
+
+Since E621 and E926 are officially supported you can also use `E621Constants.E621BaseUrl` or `E621Constants.E926BaseUrl` instead of creating a new `Uri` directly
+
 `IE621Client` instances can be disposed of, but you generally want to treat an `IE621Client` instance as a singleton. It uses a `HttpClient` behind the scenes which gets disposed when you dispose the associated `IE621Client`. You can read more about why that's bad at _[You're using HttpClient wrong and it is destabilizing your software](https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/)_ if you're interested.
 
 ## Authentication


### PR DESCRIPTION
PR for issue #17 

I have added support for the E6AI.net imageboard.
You can validate that this works by running the following code

```csharp
using Noppes.E621;

var client = new E621ClientBuilder()
    .WithUserAgent("E621Client.Tests", "n/a", "NoppesTheFolf", "GitHub")
    .WithBaseUrl(Imageboard.E6AI)
    .Build();

if (!await client.LogInAsync("NoppesTheFolf", "someapitokenfrome6ai.net"))
    throw new Exception("Could not login!");

var post = await client.GetPostAsync(52584);
if (post is null)
    throw new Exception("Could not get post data!");

Console.WriteLine(post.File?.Location);

client.Logout();
```

Please let me know if this alright to merge. It's quite a small change but I require it to add e6ai support to my bot.
Thank you!

P.S. Also let me know if I need to bump the version or if you will do that. I'm not as familiar with contributing to OS software.