### PR TITLE
Add has_notes and duration to Post, last_noted_at and duration to IqdbPost

### DIFF
--- a/E621Client/Area/Iqdb/IqdbPost.cs
+++ b/E621Client/Area/Iqdb/IqdbPost.cs
@@ -194,7 +194,8 @@ namespace Noppes.E621
                 Duration = Duration != null ? TimeSpan.FromSeconds((float)Duration) : null
         };
 
-            // Don't ignore image info on deleted posts, we want the width/height and hash
+            if (IsDeleted)
+                return post;
 
 #pragma warning disable CS8601 // Possible null reference assignment. The values will only be null if the post has been deleted.
             post.File = new PostFileImage

--- a/E621Client/Area/Iqdb/IqdbPost.cs
+++ b/E621Client/Area/Iqdb/IqdbPost.cs
@@ -134,6 +134,12 @@ namespace Noppes.E621
         [JsonProperty("is_favorited")]
         public bool IsFavorite { get; set; }
 
+        [JsonProperty("last_noted_at")]
+        public DateTimeOffset? LastNotedAt { get; set; }
+
+        [JsonProperty("duration")]
+        public double? Duration { get; set; }
+
         public IqdbPost AsPost()
         {
             var post = new IqdbPost
@@ -183,11 +189,14 @@ namespace Noppes.E621
                     IsDeleted = IsDeleted
                 },
                 CommentCount = CommentCount,
-                IsFavorite = IsFavorite
+                IsFavorite = IsFavorite,
+                HasNotes = LastNotedAt != null,
+                Duration = Duration
             };
 
-            if (IsDeleted)
-                return post;
+            // Don't ignore image info on deleted posts, we want the width/height and hash
+            //if (IsDeleted)
+            //    return post;
 
 #pragma warning disable CS8601 // Possible null reference assignment. The values will only be null if the post has been deleted.
             post.File = new PostFileImage

--- a/E621Client/Area/Iqdb/IqdbPost.cs
+++ b/E621Client/Area/Iqdb/IqdbPost.cs
@@ -195,8 +195,6 @@ namespace Noppes.E621
         };
 
             // Don't ignore image info on deleted posts, we want the width/height and hash
-            //if (IsDeleted)
-            //    return post;
 
 #pragma warning disable CS8601 // Possible null reference assignment. The values will only be null if the post has been deleted.
             post.File = new PostFileImage

--- a/E621Client/Area/Iqdb/IqdbPost.cs
+++ b/E621Client/Area/Iqdb/IqdbPost.cs
@@ -191,8 +191,8 @@ namespace Noppes.E621
                 CommentCount = CommentCount,
                 IsFavorite = IsFavorite,
                 HasNotes = LastNotedAt != null,
-                Duration = Duration
-            };
+                Duration = Duration != null ? TimeSpan.FromSeconds((float)Duration) : null
+        };
 
             // Don't ignore image info on deleted posts, we want the width/height and hash
             //if (IsDeleted)

--- a/E621Client/Area/Post/Post.cs
+++ b/E621Client/Area/Post/Post.cs
@@ -145,5 +145,17 @@ namespace Noppes.E621
         /// </summary>
         [JsonProperty("is_favorited")]
         public bool IsFavorite { get; set; }
+
+        /// <summary>
+        /// Whether the post has notes associated with it.
+        /// </summary>
+        [JsonProperty("has_notes")]
+        public bool? HasNotes { get; set; }
+
+        /// <summary>
+        /// The duration of the post, if it is a video, or null otherwise
+        /// </summary>
+        [JsonProperty("duration")]
+        public double? Duration { get; set; }
     }
 }

--- a/E621Client/Area/Post/Post.cs
+++ b/E621Client/Area/Post/Post.cs
@@ -155,7 +155,7 @@ namespace Noppes.E621
         /// <summary>
         /// The duration of the post, if it is a video, or null otherwise
         /// </summary>
-        [JsonProperty("duration")]
-        public double? Duration { get; set; }
+        [JsonProperty("duration"), JsonConverter(typeof(DurationConverter))]
+        public TimeSpan? Duration { get; set; }
     }
 }

--- a/E621Client/Converters/DurationConverter.cs
+++ b/E621Client/Converters/DurationConverter.cs
@@ -8,7 +8,7 @@ namespace Noppes.E621.Converters
     /// from a single JSON value as a string.
     /// </summary>
     /// <typeparam name="T">Type to convert to and from.</typeparam>
-    internal abstract class DurationConverter : JsonConverter<TimeSpan?>
+    internal class DurationConverter : JsonConverter<TimeSpan?>
     {
         public override void WriteJson(JsonWriter writer, TimeSpan? value, JsonSerializer serializer)
         {

--- a/E621Client/Converters/DurationConverter.cs
+++ b/E621Client/Converters/DurationConverter.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Noppes.E621.Converters
+{
+    /// <summary>
+    /// Converts duration (float) to/from TimeSpan
+    /// from a single JSON value as a string.
+    /// </summary>
+    /// <typeparam name="T">Type to convert to and from.</typeparam>
+    internal abstract class DurationConverter : JsonConverter<TimeSpan?>
+    {
+        public override void WriteJson(JsonWriter writer, TimeSpan? value, JsonSerializer serializer)
+        {
+            if (value is null) writer.WriteNull();
+            // Write TimeSpan as total seconds (as a double)
+            else writer.WriteValue(value.Value.TotalSeconds);
+        }
+
+        public override TimeSpan? ReadJson(JsonReader reader, Type objectType, TimeSpan? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null) return null;
+
+            if (reader.TokenType == JsonToken.Float || reader.TokenType == JsonToken.Integer)
+            {
+                double totalSeconds = Convert.ToDouble(reader.Value);
+                return TimeSpan.FromSeconds(totalSeconds);
+            }
+
+            throw new JsonSerializationException($"Unexpected token {reader.TokenType} when parsing TimeSpan.");
+        }
+    }
+}

--- a/E621Client/Converters/DurationConverter.cs
+++ b/E621Client/Converters/DurationConverter.cs
@@ -4,10 +4,8 @@ using System;
 namespace Noppes.E621.Converters
 {
     /// <summary>
-    /// Converts duration (float) to/from TimeSpan
-    /// from a single JSON value as a string.
+    /// Converts duration (float) to/from TimeSpan.
     /// </summary>
-    /// <typeparam name="T">Type to convert to and from.</typeparam>
     internal class DurationConverter : JsonConverter<TimeSpan?>
     {
         public override void WriteJson(JsonWriter writer, TimeSpan? value, JsonSerializer serializer)

--- a/E621Client/Converters/DurationConverter.cs
+++ b/E621Client/Converters/DurationConverter.cs
@@ -22,10 +22,7 @@ namespace Noppes.E621.Converters
             if (reader.TokenType == JsonToken.Null) return null;
 
             if (reader.TokenType == JsonToken.Float || reader.TokenType == JsonToken.Integer)
-            {
-                double totalSeconds = Convert.ToDouble(reader.Value);
-                return TimeSpan.FromSeconds(totalSeconds);
-            }
+                return TimeSpan.FromSeconds(Convert.ToDouble(reader.Value));
 
             throw new JsonSerializationException($"Unexpected token {reader.TokenType} when parsing TimeSpan.");
         }


### PR DESCRIPTION
Duration was implemented in DbExportClient but missing elsewhere, now it's fully implemented.
has_notes is also implemented. Sadly, the DB export does not have this information so when working with database posts, the Note API endpoint has to be called to know if a post even has notes available (separate pull request for that feature coming right up)